### PR TITLE
[WIP]: housekeeping

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "path": "node_modules/cz-conventional-changelog"
     }
   },
+  "preferGlobal": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/kentcdodds/generator-kcd-oss.git"


### PR DESCRIPTION
A yeoman generator is supposed to be installed globally.
So by setting `preferGlobal: true` will make the installation instruction
of this package on npmjs.com matches that intention.

then it'll be written as `npm install -g generator-kcd-oss`
insted of `npm i generator-kcd-oss`