### PR TITLE
add npx blurb to readme

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -26,6 +26,16 @@
       "contributions": [
         "doc"
       ]
+    },
+    {
+      "login": "edm00se",
+      "name": "Eric McCormick",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/622118?v=4",
+      "profile": "https://edm00se.codes/",
+      "contributions": [
+        "doc"
+      ]
     }
-  ]
+  ],
+  "repoType": "github"
 }

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [generator-kcd-oss](#generator-kcd-oss)
+  - [The problem](#the-problem)
+  - [This solution](#this-solution)
+  - [Installation](#installation)
+    - [Try Without Installing](#try-without-installing)
+  - [Usage](#usage)
+  - [Inspiration](#inspiration)
+  - [Contributors](#contributors)
+  - [LICENSE](#license)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 <div align="center">
 <h1>generator-kcd-oss</h1>
 
@@ -9,9 +24,9 @@
 [![Build Status][build-badge]][build]
 [![version][version-badge]][package]
 [![downloads][downloads-badge]][npmtrends]
-[![MIT License][license-badge]][LICENSE]
+[![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-2-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Code of Conduct][coc-badge]][coc]
 
@@ -59,8 +74,10 @@ I referenced [@sindresorhus][sindresorhus]'s [module][generator-nm] heavily.
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](http://kent.doddsfamily.us)<br />[💻](https://github.com/kentcdodds/generator-kcd-oss/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/generator-kcd-oss/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/3415488?v=4" width="100px;"/><br /><sub>Anup</sub>](https://github.com/reznord)<br />[📖](https://github.com/kentcdodds/generator-kcd-oss/commits?author=reznord "Documentation") |
-| :---: | :---: |
+<!-- prettier-ignore -->
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](http://kent.doddsfamily.us)<br />[💻](https://github.com/kentcdodds/generator-kcd-oss/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/generator-kcd-oss/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") | [<img src="https://avatars0.githubusercontent.com/u/3415488?v=4" width="100px;"/><br /><sub><b>Anup</b></sub>](https://github.com/reznord)<br />[📖](https://github.com/kentcdodds/generator-kcd-oss/commits?author=reznord "Documentation") | [<img src="https://avatars3.githubusercontent.com/u/622118?v=4" width="100px;"/><br /><sub><b>Eric McCormick</b></sub>](https://edm00se.codes/)<br />[📖](https://github.com/kentcdodds/generator-kcd-oss/commits?author=edm00se "Documentation") |
+| :---: | :---: | :---: |
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ be installed globally (with `yo`):
 npm install -g generator-kcd-oss yo
 ```
 
+### Try Without Installing
+
+```sh
+npx -p yo -p generator-kcd-oss -c 'yo kcd-oss'
+```
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-
-- [generator-kcd-oss](#generator-kcd-oss)
-  - [The problem](#the-problem)
-  - [This solution](#this-solution)
-  - [Installation](#installation)
-    - [Try Without Installing](#try-without-installing)
-  - [Usage](#usage)
-  - [Inspiration](#inspiration)
-  - [Contributors](#contributors)
-  - [LICENSE](#license)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 <div align="center">
 <h1>generator-kcd-oss</h1>
 


### PR DESCRIPTION
Adds instruction to the readme for how to use `generator-kcd-oss` without installing it, or `yo`, globally. It makes use of `npx` and can reduce the hurdle for some people with trying out a project.