### PR TITLE
Fixed the husky hook for pre-commit

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -28,7 +28,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "kcd-scripts precommit"
+      "pre-commit": "kcd-scripts pre-commit"
     }
   },
   "eslintConfig": {


### PR DESCRIPTION
An action `precommit` doesn't exist in `kcd-scripts` but `pre-commit` does, fixing template file