### PR TITLE
fix: mv the validate files to .github folder

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -42,6 +42,7 @@ module.exports = class extends Generator {
       mv('prettierignore', '.prettierignore')
       mv('github/ISSUE_TEMPLATE.md', '.github/ISSUE_TEMPLATE.md')
       mv('github/PULL_REQUEST_TEMPLATE.md', '.github/PULL_REQUEST_TEMPLATE.md')
+      mv('github/workflows/validate.yml', '.github/workflows/validate.yml')
     })
   }
   install() {


### PR DESCRIPTION
Following [this](https://github.com/testing-library/react-testing-library/pull/826#issuecomment-727170257) comment by @nickmccurdy, this will `mv` to workflow file to `.github` folder also :)