### PR TITLE
feat: add cancel previous runs action step

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,6 +19,11 @@ jobs:
         node: [10.13, 12, 14, 15]
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2
 

--- a/generators/app/templates/github/workflows/validate.yml
+++ b/generators/app/templates/github/workflows/validate.yml
@@ -19,6 +19,11 @@ jobs:
         node: [10.13, 12, 14, 15]
     runs-on: ubuntu-latest
     steps:
+      - name: 🛑 Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2
 


### PR DESCRIPTION
If a new commit is pushed, this will cancel the previous run. Should speed up builds of the most relevant commit.